### PR TITLE
maplist min/max (#4)

### DIFF
--- a/g_items.c
+++ b/g_items.c
@@ -29,7 +29,7 @@ extern void Weapon_Plasma (edict_t *ent);
 extern void Use_PLASMA (edict_t *ent, gitem_t *inv);
 // END
 
-
+int quad_respawn_time;
 
 void Weapon_Hook (edict_t *ent); // CTF CODE -- LM_JORM
 
@@ -1918,7 +1918,7 @@ always owned, never in the world
 /* icon */		"p_quad",
 /* pickup */	"Quad Damage",
 /* width */		2,
-		60,  //Quad respawn time right here
+		LM_QUAD_DEFAULT_TIME,  //Quad respawn time right here
 		NULL,
 		IT_POWERUP,
 		0,

--- a/g_local.h
+++ b/g_local.h
@@ -33,7 +33,7 @@ _CrtMemState startup1;	// memory diagnostics
 #include "game.h"
 
 // the "gameversion" client command will print this plus compile date
-#define GAMEVERSION     "LMCTF 6.2"
+#define GAMEVERSION     "LMCTF 6.2-raven"
 
 #include "p_stats.h" // STATS - LM_Hati
 #include "g_menu.h" // MENUS - LM_Jorm
@@ -587,12 +587,19 @@ extern  cvar_t* flag_init;
 extern  cvar_t  *use_zbotdetect; // CTF CODE -- LM_Hati
 #endif
 
+typedef struct MapInfo {
+	char *mapname;
+	int  minplayers;
+	int  maxplayers;
+        struct MapInfo *next;
+} MapInfo;
+
 extern  edict_t *redflag; // CTF CODE -- LM_JORM
 extern  edict_t *blueflag; // CTF CODE -- LM_JORM
 
 extern  char    motd[1000]; // CTF CODE -- LM_JORM
 
-extern  char    maplist[100][100]; // CTF CODE -- LM_JORM
+extern  MapInfo maplist[300]; // CTF CODE -- LM_JORM
 extern  int     maplistindex; // CTF CODE -- LM_JORM
 
 extern  int     bluescore, redscore; // CTF CODE -- LM_JORM
@@ -646,7 +653,9 @@ typedef struct
 extern	field_t fields[];
 extern	gitem_t	itemlist[];
 
-
+void SortMaplist(MapInfo arr[], int min, int max);
+int MapDivide(MapInfo arr[], int min, int max);
+void flip(MapInfo* x, MapInfo* y);
 //
 // g_cmds.c
 //
@@ -1323,4 +1332,5 @@ struct edict_s
 	// END CTF CODE
 };
 
+#define LM_QUAD_DEFAULT_TIME 60
 #endif

--- a/g_menu.c
+++ b/g_menu.c
@@ -58,12 +58,19 @@ void ClearPassword_Exec (edict_t *ent);
 void Ref_Kick_Menu (edict_t *ent);
 void RefTogglePause(edict_t *ent);
 void Ref_Map_Menu (edict_t *ent);
+void SetMapsForMenu (edict_t *ent);
+void SetupShortList ();
+void MapMenu (edict_t *ent, char *maplist[], char *msg);
 void Ref_Match_A_Menu (edict_t *ent);
 void Ref_Match_B_Menu (edict_t *ent);
 void Ref_Match_C_Menu (edict_t *ent);
+void Ref_Match_D_Menu (edict_t *ent);
+void Ref_Match_E_Menu (edict_t *ent);
 void Ref_Map_A_Menu (edict_t *ent);
 void Ref_Map_B_Menu (edict_t *ent);
 void Ref_Map_C_Menu (edict_t *ent);
+void Ref_Map_D_Menu (edict_t *ent);
+void Ref_Map_E_Menu (edict_t *ent);
 void Ref_Match_Maplist_Menu (edict_t *ent);
 void Ref_Map_Maplist_Menu (edict_t *ent);
 
@@ -74,6 +81,9 @@ extern void Observer_Start (edict_t *ent);
 void Change_Team_Exec(edict_t *ent);
 void Observe_Exec(edict_t *ent);
 void Cmd_Observe_f(edict_t *ent, int Observer_Type);
+
+
+MapInfo *shortList = NULL;
 
 
 menuitem mainmenu[] =
@@ -1035,7 +1045,8 @@ void Ref_Settings_Menu (edict_t *ent)
 	ent->client->menu = MENU_LOCAL;
 	ent->client->menuselect = 1;
 
-
+	gitem_t *quad;
+	quad = FindItem("Quad Damage");
 	Menu_Set(ent, 1, "Server Settings", Ref_Main_Menu);
 	Menu_Set(ent, 2, "---------------", NULL);
 	sprintf(text, "Timelimit:           %3d", (int)timelimit->value);	
@@ -1046,11 +1057,20 @@ void Ref_Settings_Menu (edict_t *ent)
 	Menu_Set(ent, 5, text, Ref_DMFlags_Menu);
 	sprintf(text, "CTFFlags:          %5d", ((unsigned short)ctfflags->value));	
 	Menu_Set(ent, 6, text, Ref_CTFFlags_Menu);
-	sprintf(text, "Password: %s", password->string);
+	cvar_t *svp = gi.cvar("sv_password","",0);
+	if (svp && strlen(svp->string) > 0) {
+		sprintf(text, "sv_password: %s", svp->string);
+	} else {
+		sprintf(text, "password: %s", password->string);
+	}
 	Menu_Set(ent, 7, text, NULL);
 	if (ent->client->ctf.extra_flags & CTF_EXTRAFLAGS_RCON)
 		Menu_Set(ent, 8, "Clear password (RCON)", ClearPassword_Exec);
-	
+	if (quad) {
+		sprintf(text, "Quad Time: %i", quad->quantity);
+		Menu_Set(ent, 9, text, NULL);
+	}
+
 
 	Menu_Draw (ent);
 }
@@ -1292,10 +1312,10 @@ char *mapalist[] =
 	0,
 	0,
 	"lmctf01",
-	"lmctf02",
+	"lmctf02c",
 	"lmctf03",
 	"lmctf04",
-	"lmctf05",
+	"lmctf05c",
 	"lmctf06",
 	"lmctf07",
 	"lmctf08",
@@ -1353,8 +1373,102 @@ char *mapclist[] =
 	0
 };
 
+char *mapdlist[] =
+{
+	0,
+	0,
+	"lmctf31",
+	"lmctf32",
+	"lmctf33",
+	"lmctf34",
+	"lmctf35",
+	"lmctf36",
+	"lmctf37",
+	"lmctf38",
+	"lmctf39",
+	"lmctf40",
+	0,
+	0,
+	0,
+	0,
+	0,
+	0
+};
 
+char *mapelist[] =
+{
+	0,
+	0,
+	"lmctf41",
+	"lmctf42",
+	"lmctf43",
+	"lmctf44",
+	"lmctf45",
+	"lmctf46",
+	"lmctf47",
+	"lmctf48",
+	"lmctf49",
+	0,
+	0,
+	0,
+	0,
+	0,
+	0,
+	0
+};
 
+char *maplmlist[] =
+{
+        "lmctf01",
+        "lmctf02c",
+        "lmctf03",
+        "lmctf04",
+        "lmctf05c",
+        "lmctf06",
+        "lmctf07",
+        "lmctf08",
+        "lmctf09",
+        "lmctf10",
+        "lmctf11",
+        "lmctf12",
+        "lmctf13",
+        "lmctf14",
+        "lmctf15",
+        "lmctf16",
+        "lmctf17",
+        "lmctf18",
+        "lmctf19",
+        "lmctf20",
+        "lmctf21",
+        "lmctf22",
+        "lmctf23",
+        "lmctf24",
+        "lmctf25",
+        "lmctf26",
+        "lmctf27",
+        "lmctf28",
+        "lmctf29",
+        "lmctf30",
+        "lmctf31",
+        "lmctf32",
+        "lmctf33",
+        "lmctf34",
+        "lmctf35",
+        "lmctf36",
+        "lmctf37",
+        "lmctf38",
+        "lmctf39",
+        "lmctf40",
+        "lmctf41",
+        "lmctf42",
+        "lmctf43",
+        "lmctf44",
+        "lmctf45",
+        "lmctf46",
+        "lmctf47",
+        "lmctf48",
+        "lmctf49"
+};
 /*
 void SetMatchBMap (edict_t *ent)
 {
@@ -1379,6 +1493,8 @@ void SetBMap (edict_t *ent)
 void SetMap (edict_t *ent)
 {
 	int i;
+	SetupShortList();
+	MapInfo *slPtr = shortList;
 
 	if (ent->client->prevmenu == Ref_Match_A_Menu)
 	{
@@ -1395,11 +1511,24 @@ void SetMap (edict_t *ent)
 		Ctf_Menu(ent); // turn off menu
 		StartMatch (mapclist[ent->client->menuselect]);
 	}
+	else if (ent->client->prevmenu == Ref_Match_D_Menu)
+	{
+		Ctf_Menu(ent); // turn off menu
+		StartMatch (mapdlist[ent->client->menuselect]);
+	}
+	else if (ent->client->prevmenu == Ref_Match_E_Menu)
+	{
+		Ctf_Menu(ent); // turn off menu
+		StartMatch (mapelist[ent->client->menuselect]);
+	}
 	else if (ent->client->prevmenu == Ref_Match_Maplist_Menu)
 	{
 		Ctf_Menu(ent); // turn off menu
 		i = (ent->client->menuselect - 2)+ent->client->menulastpage*15;
-		StartMatch (maplist[i]);
+	 	for (int ctr = 0; ctr < i && slPtr; ctr++)
+			slPtr = slPtr->next;
+		if (slPtr)
+			StartMatch (slPtr->mapname);
 	}
 	else if (ent->client->prevmenu == Ref_Map_A_Menu)
 	{
@@ -1416,46 +1545,36 @@ void SetMap (edict_t *ent)
 		Ctf_Menu(ent); // turn off menu
 		ctf_ChangeMap(mapclist[ent->client->menuselect], false);
 	}
+	else if (ent->client->prevmenu == Ref_Map_D_Menu)
+	{
+		Ctf_Menu(ent); // turn off menu
+		ctf_ChangeMap(mapdlist[ent->client->menuselect], false);
+	}
+	else if (ent->client->prevmenu == Ref_Map_E_Menu)
+	{
+		Ctf_Menu(ent); // turn off menu
+		ctf_ChangeMap(mapelist[ent->client->menuselect], false);
+	}
 	else if (ent->client->prevmenu == Ref_Map_Maplist_Menu)
 	{
 		Ctf_Menu(ent); // turn off menu
 		i = (ent->client->menuselect - 2)+ent->client->menulastpage*15;
-		ctf_ChangeMap(maplist[i], false);
+	 	for (int ctr = 0; ctr < i && slPtr; ctr++)
+			slPtr = slPtr->next;
+		if (slPtr)
+			ctf_ChangeMap(slPtr->mapname, false);
 	}
 }
 
 void Ref_Match_Maplist_Menu (edict_t *ent)
 {
-	char text[MAX_INFO_STRING];
-	int i,j, start;
-
-	// Calculate our page
-	start = 15*ent->client->menupage;
-	
-	// Find if last page was the last
-	if (start > 14)
-	{
-		for (i=start-15;i < start; i++)
-		{
-			if (!maplist[i][0]) // Last entry
-			{
-				start = 0;			// Go to first page
-				ent->client->menupage = 0;
-			}
-		}
-	}
-
 	Menu_Free(ent);
 	ent->client->menu = MENU_LOCAL;
 	ent->client->menuselect = 0;
 
-	Menu_Set(ent, 0, "Match Maplist", Ref_Main_Menu);
+	Menu_Set(ent, 0, "Match Maplist <min> <max>", Ref_Main_Menu);
 	Menu_Set(ent, 1, "-------------", NULL);
-	for (i=2, j=start; i < 17 && maplist[j][0]; i++, j++)
-	{
-		sprintf(text, "%s", maplist[j]);
-		Menu_Set(ent, i, text, SetMap);
-	}
+	SetMapsForMenu(ent);
 	Menu_Set(ent, 17, "<next page>", Ref_Match_Maplist_Menu);
 
 	Menu_Draw (ent);
@@ -1463,184 +1582,162 @@ void Ref_Match_Maplist_Menu (edict_t *ent)
 
 void Ref_Map_Maplist_Menu (edict_t *ent)
 {
-	char text[MAX_INFO_STRING];
-	int i,j, start;
-
-	// Calculate our page
-	start = 15*ent->client->menupage;
-	
-	// Find if last page was the last
-	if (start > 14)
-	{
-		for (i=start-15;i < start; i++)
-		{
-			if (!maplist[i][0]) // Last entry
-			{
-				start = 0;			// Go to first page
-				ent->client->menupage = 0;
-			}
-		}
-	}
-
 	Menu_Free(ent);
 	ent->client->menu = MENU_LOCAL;
 	ent->client->menuselect = 0;
 
-	Menu_Set(ent, 0, "Maplist", Ref_Main_Menu);
-	Menu_Set(ent, 1, "-------", NULL);
-	for (i=2, j=start; i < 17 && maplist[j][0]; i++, j++)
-	{
-		sprintf(text, "%s", maplist[j]);
-		Menu_Set(ent, i, text, SetMap);
-	}
+	Menu_Set(ent, 0, "Maplist <min> <max>", Ref_Main_Menu);
+	Menu_Set(ent, 1, "-------------", NULL);
+	SetMapsForMenu(ent);
 	Menu_Set(ent, 17, "<next page>", Ref_Map_Maplist_Menu);
 
 	Menu_Draw (ent);
 }
 
-
-void Ref_Match_A_Menu (edict_t *ent)
+void SetMapsForMenu( edict_t *ent)
 {
 	char text[MAX_INFO_STRING];
+	int start;
+
+	SetupShortList();
+
+	MapInfo *slPtr = shortList;
+
+	// Calculate our page
+	start = 15*ent->client->menupage;
+
+	slPtr = shortList;
+	int mapCtr = 0;
+	while (slPtr) {
+		mapCtr++;
+		slPtr = slPtr->next;
+	}
+
+	// Find if last page was the last
+	if (start > 14)
+	{
+		if (start + 15 >= mapCtr)
+		{
+			start = 0;
+			ent->client->menupage = 0;
+		}
+	}
+
+	slPtr = shortList;
+	for (int ct = 0; ct < start; ct++)
+		slPtr = slPtr->next;
+
+
+	for (int endCtr = 2; endCtr < 18 && slPtr; endCtr++) {
+		sprintf(text, "%s %d %d", slPtr->mapname, slPtr->minplayers, slPtr->maxplayers);
+		Menu_Set(ent, endCtr, text, SetMap);
+		slPtr = slPtr->next;
+	}
+}
+
+void SetupShortList()
+{
+	if (shortList)
+	{
+		return;
+	}
+        MapInfo *slPtr = NULL;
+        for(int ctr = 0; maplist[ctr].mapname; ctr++) {
+                char *thisMap = maplist[ctr].mapname;
+                for(int lmNdx = 0; maplmlist[lmNdx]; lmNdx++) {
+                        if (!strcmp(maplmlist[lmNdx], thisMap)) {
+                                goto end;
+                        }
+                }
+                if (!slPtr) {
+                        shortList = slPtr = &maplist[ctr];
+			slPtr->next = NULL;
+                } else {
+                        slPtr->next = &maplist[ctr];
+                        slPtr = slPtr->next;
+                        slPtr->next = NULL;
+                }
+                end:
+                        continue;
+        }
+}
+
+
+void MapMenu(edict_t *ent, char *maplist[], char *msg)
+{
+	char text[MAX_INFO_STRING];
+        char title[MAX_INFO_STRING];
 	int i;
 
 	Menu_Free(ent);
 	ent->client->menu = MENU_LOCAL;
 	ent->client->menuselect = 0;
 
-	Menu_Set(ent, 0, "Set 1 Match", Ref_Main_Menu);
+	sprintf(title, "%s", msg);
+
+	Menu_Set(ent, 0, title, ent->client->prevmenu);
 	Menu_Set(ent, 1, "-----------", NULL);
 	for (i=2; i < 18; i++)
 	{
-		if (mapalist[i])
+		if (maplist[i])
 		{
-			sprintf(text, "%s", mapalist[i]);
+			sprintf(text, "%s", maplist[i]);
 			Menu_Set(ent, i, text, SetMap);
 		}
 	}
 
 	Menu_Draw (ent);
+}
+
+void Ref_Match_A_Menu (edict_t *ent)
+{
+	MapMenu(ent, mapalist, "Set 1 maps");
 }
 
 void Ref_Map_A_Menu (edict_t *ent)
 {
-	char text[MAX_INFO_STRING];
-	int i;
-
-	Menu_Free(ent);
-	ent->client->menu = MENU_LOCAL;
-	ent->client->menuselect = 0;
-
-	Menu_Set(ent, 0, "Set 1 Maps", Ref_Main_Menu);
-	Menu_Set(ent, 1, "----------", NULL);
-	for (i=2; i < 18; i++)
-	{
-		if (mapalist[i])
-		{
-			sprintf(text, "%s", mapalist[i]);
-			Menu_Set(ent, i, text, SetMap);
-		}
-	}
-
-	Menu_Draw (ent);
+	MapMenu(ent, mapalist, "Set 1 Maps");
 }
 
 void Ref_Match_B_Menu (edict_t *ent)
 {
-	char text[MAX_INFO_STRING];
-	int i;
-
-	Menu_Free(ent);
-	ent->client->menu = MENU_LOCAL;
-	ent->client->menuselect = 0;
-
-	Menu_Set(ent, 0, "Set 2 Match", Ref_Main_Menu);
-	Menu_Set(ent, 1, "-----------", NULL);
-	for (i=2; i < 18; i++)
-	{
-		if (mapblist[i])
-		{
-			sprintf(text, "%s", mapblist[i]);
-			Menu_Set(ent, i, text, SetMap);
-		}
-	}
-
-	Menu_Draw (ent);
+	MapMenu(ent, mapblist, "Set 2 Maps");
 }
-
-
-void Ref_Match_C_Menu (edict_t *ent)
-{
-	char text[MAX_INFO_STRING];
-	int i;
-
-	Menu_Free(ent);
-	ent->client->menu = MENU_LOCAL;
-	ent->client->menuselect = 0;
-
-	Menu_Set(ent, 0, "Set 3 Match", Ref_Main_Menu);
-	Menu_Set(ent, 1, "-----------", NULL);
-	for (i=2; i < 18; i++)
-	{
-		if (mapclist[i])
-		{
-			sprintf(text, "%s", mapclist[i]);
-			Menu_Set(ent, i, text, SetMap);
-		}
-	}
-
-	Menu_Draw (ent);
-}
-
 
 void Ref_Map_B_Menu (edict_t *ent)
 {
-	char text[MAX_INFO_STRING];
-	int i;
-
-	Menu_Free(ent);
-	ent->client->menu = MENU_LOCAL;
-	ent->client->menuselect = 0;
-
-	Menu_Set(ent, 0, "Set 2 Maps", Ref_Main_Menu);
-	Menu_Set(ent, 1, "----------", NULL);
-	for (i=2; i < 18; i++)
-	{
-		if (mapblist[i])
-		{
-			sprintf(text, "%s", mapblist[i]);
-			Menu_Set(ent, i, text, SetMap);
-		}
-	}
-
-	Menu_Draw (ent);
+	MapMenu(ent, mapblist, "Set 2 Maps");
 }
 
+void Ref_Match_C_Menu (edict_t *ent)
+{
+	MapMenu(ent, mapclist, "Set 3 Maps");
+}
 
 void Ref_Map_C_Menu (edict_t *ent)
 {
-	char text[MAX_INFO_STRING];
-	int i;
-
-	Menu_Free(ent);
-	ent->client->menu = MENU_LOCAL;
-	ent->client->menuselect = 0;
-
-	Menu_Set(ent, 0, "Set 3 Maps", Ref_Main_Menu);
-	Menu_Set(ent, 1, "----------", NULL);
-	for (i=2; i < 18; i++)
-	{
-		if (mapclist[i])
-		{
-			sprintf(text, "%s", mapclist[i]);
-			Menu_Set(ent, i, text, SetMap);
-		}
-	}
-
-	Menu_Draw (ent);
+	MapMenu(ent, mapclist, "Set 3 Maps");
 }
 
+void Ref_Match_D_Menu (edict_t *ent)
+{
+	MapMenu(ent, mapdlist, "Set 4 Maps");
+}
 
+void Ref_Map_D_Menu (edict_t *ent)
+{
+	MapMenu(ent, mapdlist, "Set 4 Maps");
+}
+
+void Ref_Match_E_Menu (edict_t *ent)
+{
+	MapMenu(ent, mapelist, "Set 5 Maps");
+}
+
+void Ref_Map_E_Menu (edict_t *ent)
+{
+	MapMenu(ent, mapelist, "Set 5 Maps");
+}
 
 void Ref_End_Match (edict_t *ent)
 {
@@ -1660,8 +1757,10 @@ void Ref_Match_Menu (edict_t *ent)
 	Menu_Set(ent, 2, "LMCTF Set 1", Ref_Match_A_Menu);
 	Menu_Set(ent, 3, "LMCTF Set 2", Ref_Match_B_Menu);
 	Menu_Set(ent, 4, "LMCTF Set 3", Ref_Match_C_Menu);
+	Menu_Set(ent, 5, "LMCTF Set 4", Ref_Match_D_Menu);
+	Menu_Set(ent, 6, "LMCTF Set 5", Ref_Match_E_Menu);
 	if (maplistindex != -2) // No list
-		Menu_Set(ent, 5, "Maplist", Ref_Match_Maplist_Menu);
+		Menu_Set(ent, 7, "Maplist", Ref_Match_Maplist_Menu);
 	Menu_Draw (ent);
 }
 
@@ -1677,8 +1776,10 @@ void Ref_Map_Menu (edict_t *ent)
 	Menu_Set(ent, 2, "LMCTF Set 1", Ref_Map_A_Menu);
 	Menu_Set(ent, 3, "LMCTF Set 2", Ref_Map_B_Menu);
 	Menu_Set(ent, 4, "LMCTF Set 3", Ref_Map_C_Menu);
+	Menu_Set(ent, 5, "LMCTF Set 4", Ref_Map_D_Menu);
+	Menu_Set(ent, 6, "LMCTF Set 5", Ref_Map_E_Menu);
 	if (maplistindex != -2) // No list
-		Menu_Set(ent, 5, "Maplist", Ref_Map_Maplist_Menu);
+		Menu_Set(ent, 7, "Maplist", Ref_Map_Maplist_Menu);
 
 	Menu_Draw (ent);
 }

--- a/g_save.c
+++ b/g_save.c
@@ -275,15 +275,32 @@ void InitGame (void)
 			maplistindex = 0;
 			while ( fgets(line, 255, file) )
 			{
-				if (sscanf(line, "%s", maplist[maplistindex]))
-				{
-					// convert to lower case for subsequent comparisons
-					for (i = 0; i < (int)strlen(maplist[maplistindex]); i++)
-						maplist[maplistindex][i] = tolower(maplist[maplistindex][i]);
-					maplistindex++;
+				char *tempname = gi.TagMalloc(100, TAG_GAME);
+				int tempmin = 0;
+				int tempmax = 99;
+				if (sscanf(line, "%s %d %d", tempname, &tempmin, &tempmax) != 3) {
+					if (sscanf(line, "%s %d", tempname, &tempmin) != 2) {
+						if (sscanf(line, "%s", tempname) != 1) {
+							sprintf(line, "Bad entry in maplist");
+							gi.dprintf(line);
+							gi.TagFree(tempname);
+							continue;
+						}
+					}
 				}
+//, maplist[maplistindex]))
+				// convert to lower case for subsequent comparisons
+				for (i = 0; i < strlen(tempname); i++)
+					tempname[i] = tolower(tempname[i]);
+				maplist[maplistindex].mapname = tempname;
+				maplist[maplistindex].minplayers = tempmin;
+				maplist[maplistindex].maxplayers = tempmax;
+
+				maplistindex++;
+
 			}
-			maplist[maplistindex][0] = 0; // Blank last entry
+			SortMaplist(maplist, 0, maplistindex-1);
+//			maplist[maplistindex][0] = 0; // Blank last entry
 			sprintf(line, "%d entries in maplist.\n", maplistindex);
 			gi.dprintf(line);
 			fclose(file);
@@ -357,6 +374,37 @@ void InitGame (void)
 	// END CTF CODE -- LM_JORM
 
 }
+
+void SortMaplist(MapInfo arr[], int min, int max) {
+	if (min < max) {
+		int ndx = MapDivide(arr, min, max);
+		SortMaplist(arr, min, ndx - 1);
+		SortMaplist(arr, ndx + 1, max);
+	}
+}
+
+
+int MapDivide(MapInfo arr[], int min, int max) {
+	MapInfo tmp = arr[max];
+	int nndx = (min - 1);
+
+	for (int x = min; x <= max-1; x++) {
+		if (strcmp(arr[x].mapname, tmp.mapname) < 0) {
+			nndx++;
+			flip(&arr[nndx], &arr[x]);
+		}
+	}
+	flip(&arr[nndx+1], &arr[max]);
+	return(nndx + 1);
+}
+
+void flip(MapInfo* x, MapInfo* y) {
+	MapInfo tmp = *x;
+	*x = *y;
+	*y=  tmp;
+}
+
+
 
 //=========================================================
 

--- a/g_svcmds.c
+++ b/g_svcmds.c
@@ -1,5 +1,6 @@
-
 #include "g_local.h"
+
+void ctf_BSafePrint(long print_priority, char * buf);
 
 
 void	Svcmd_Test_f (void)
@@ -261,6 +262,32 @@ void SVCmd_WriteIP_f (void)
 	fclose(f);
 }
 
+void SVCmd_QuadTime_f(void)
+{
+        unsigned long i=0;
+        gitem_t * target = NULL;
+
+        if (gi.argc() < 3) {
+                gi.cprintf(NULL, PRINT_HIGH, "Usage:  sv quadtime <seconds>\n");
+                return;
+        }
+
+        if (!sscanf(gi.argv(2), "%lu", &i))
+        {
+	        gi.cprintf(NULL, PRINT_HIGH, "Usage: sv quadtime <seconds>\n");
+
+                return;
+        }
+
+        target = FindItem("Quad Damage");
+        if (target && i > 0 && i < 1200) {
+                target->quantity = i;
+		char buffer[MAX_INFO_STRING];
+		sprintf(buffer, "Quad respawn updated to %lu\n", i);
+		ctf_BSafePrint(PRINT_HIGH, buffer);
+        }
+}
+
 /*
 =================
 ServerCommand
@@ -285,7 +312,9 @@ void	ServerCommand (void)
 		SVCmd_ListIP_f ();
 	else if (Q_stricmp (cmd, "writeip") == 0)
 		SVCmd_WriteIP_f ();
-	if ((Q_stricmp (cmd, "next") == 0) || (Q_stricmp (cmd, "skip") == 0))
+	else if (Q_stricmp (cmd, "quadtime") == 0)
+		SVCmd_QuadTime_f ();
+	else if ((Q_stricmp (cmd, "next") == 0) || (Q_stricmp (cmd, "skip") == 0))
 		Svcmd_NextLevel_f ();
 	else
 		gi.cprintf (NULL, PRINT_HIGH, "Unknown server command \"%s\"\n", cmd);


### PR DESCRIPTION
sort the list

filter out lmmaps

adding maps 30-48

remove 49,50

lets null them instead of 0 them

menu consolidation

maplist size 300, use prevmenu in maplist headers

make random map selection pay attention to min/max players vs settings in maplist

map selection logging

randomize startup map

quad respawn to 2m, adding referee command 'fobserve <clientid>'

back to c11

referee quadtime command

Add quadtime command to refere and console

consolidate menuing between match and setmap

consolidate map menu lookup menu

lmctf02 and lmctf05 are broken with default ents, so removing from menu for now

display q2pro password var in ctfmenu if set

This type isn\'t allowed on the fly

force slPtr->next to NULL when initializing list

readd lm02&05 as lmctf02c and lmctf05c as we have a fixed versions now

how did this get back in?

Co-authored-by: Marc Hassman <marc@hassman.us>